### PR TITLE
Make code compatible for Swift projects

### DIFF
--- a/DPHue/DPHueBridge.h
+++ b/DPHue/DPHueBridge.h
@@ -22,12 +22,12 @@
  The API username DPHueBridge will use when communicating with the Hue controller.
  The generatedUsername is created by the Hue bridge when linking the device with the bridge.
  */
-@property (nonatomic, copy) NSString *generatedUsername;
+@property (nonatomic, copy) NSString * _Nullable generatedUsername;
 
 /**
  legacyUsername, may no longer be accepted by new bridges.
  */
-@property (nonatomic, copy) NSString *legacyUsername;
+@property (nonatomic, copy) NSString * _Nullable legacyUsername;
 
 /// The hostname (or IP address) that DPHueBridge will talk to.
 @property (nonatomic, copy) NSString *host;
@@ -76,7 +76,7 @@
  *          An md5 string from a previously successful call to @p [DPHueBridge registerDevice].
  *          If this is your first time interacting with the controller, use @p nil.
  */
-- (id)initWithHueHost:(NSString *)host generatedUsername:(NSString *)generatedUsername;
+- (id)initWithHueHost:(NSString *)host generatedUsername:(NSString * _Nullable)generatedUsername;
 
 /**
  Download the complete state of the Hue controller, including the state

--- a/DPHue/DPHueBridge.h
+++ b/DPHue/DPHueBridge.h
@@ -98,7 +98,7 @@
  */
 - (void)registerDevice;
 
-- (void)registerDeviceWithCompletion:(void(^_Nullable)(DPHueBridge* sender, id json, NSError* error))completion;
+- (void)registerDeviceWithCompletion:(void(^_Nullable)(DPHueBridge* sender, id _Nullable json, NSError* _Nullable error))completion;
 
 /**
  Triggers the Touchlink feature in a Hue controller, which causes it to

--- a/DPHue/DPHueBridge.m
+++ b/DPHue/DPHueBridge.m
@@ -143,7 +143,7 @@ const DPHueCommandQueueKey* DPHueCommandQueueKeyExpire = @"DPHueCommandQueueKeyE
     [self registerDeviceWithCompletion:nil];
 }
 
-- (void)registerDeviceWithCompletion:(void(^_Nullable)(DPHueBridge* sender, id json, NSError* error))completion {
+- (void)registerDeviceWithCompletion:(void(^_Nullable)(DPHueBridge* sender, id _Nullable json, NSError* _Nullable error))completion {
     DPJSONConnection *connection = [[DPJSONConnection alloc] initWithRequest:[self requestForRegisteringDevice:self.deviceType] sender:self];
     connection.completionBlock = ^(DPHueBridge *sender, id json, NSError *err) {
         if (!err)

--- a/DPHue/DPHueBridge.m
+++ b/DPHue/DPHueBridge.m
@@ -36,7 +36,7 @@ const DPHueCommandQueueKey* DPHueCommandQueueKeyExpire = @"DPHueCommandQueueKeyE
     NSArray* commandQueue;
 }
 
-- (id)initWithHueHost:(NSString *)host generatedUsername:(NSString *)generatedUsername
+- (id)initWithHueHost:(NSString *)host generatedUsername:(NSString * _Nullable)generatedUsername
 {
   if ( self = [super init] )
   {

--- a/DPHue/DPHueDiscover.h
+++ b/DPHue/DPHueDiscover.h
@@ -19,9 +19,9 @@
 
 - (instancetype)init NS_UNAVAILABLE;
 
-+ (instancetype)discoverWithDuration:(NSInteger)duration hueFound:(void(^_Nullable)(NSString* host, NSString* mac))hueFound completion:(void(^_Nullable)(NSDictionary* discovered, NSString* log, NSError* error))completion;
++ (instancetype)discoverWithDuration:(NSInteger)duration hueFound:(void(^_Nullable)(NSString* host, NSString* mac))hueFound completion:(void(^_Nullable)(NSDictionary* discovered, NSString* _Nullable log, NSError* _Nullable error))completion;
 
-- (instancetype)initWithDuration:(NSInteger)duration hueFound:(void(^_Nullable)(NSString* host, NSString* mac))hueFound completion:(void(^_Nullable)(NSDictionary* discovered, NSString* log, NSError* error))completion;
+- (instancetype)initWithDuration:(NSInteger)duration hueFound:(void(^_Nullable)(NSString* host, NSString* mac))hueFound completion:(void(^_Nullable)(NSDictionary* discovered, NSString* _Nullable log, NSError* _Nullable error))completion;
 
 - (void)stopDiscovery;
 

--- a/DPHue/DPHueDiscover.m
+++ b/DPHue/DPHueDiscover.m
@@ -43,11 +43,11 @@ NSString* _MacAddressWithSeparators(NSString* aMacAddress) {
     void (^doCompletion)(NSDictionary* discovered, NSString* log, NSError* error);
 }
 
-+ (instancetype)discoverWithDuration:(NSInteger)duration hueFound:(void(^_Nullable)(NSString* host, NSString* mac))hueFound completion:(void(^_Nullable)(NSDictionary* discovered, NSString* log, NSError* error))completion {
++ (instancetype)discoverWithDuration:(NSInteger)duration hueFound:(void(^_Nullable)(NSString* host, NSString* mac))hueFound completion:(void(^_Nullable)(NSDictionary* discovered, NSString* _Nullable log, NSError* _Nullable error))completion {
     return [[DPHueDiscover alloc] initWithDuration:duration hueFound:hueFound completion:completion];
 }
 
-- (instancetype)initWithDuration:(NSInteger)duration hueFound:(void(^_Nullable)(NSString* host, NSString* mac))hueFound completion:(void(^_Nullable)(NSDictionary* discovered, NSString* log, NSError* error))completion {
+- (instancetype)initWithDuration:(NSInteger)duration hueFound:(void(^_Nullable)(NSString* host, NSString* mac))hueFound completion:(void(^_Nullable)(NSDictionary* discovered, NSString* _Nullable log, NSError* _Nullable error))completion {
     self = [super init];
     if (self) {
         [self discoverHueForDuration:duration hueFound:hueFound completion:completion];


### PR DESCRIPTION
I added some `_Nullable` for references that can be `nil`. Otherwise Swift would assume them to be non-optional. When accessing them when they were in fact `nil` it then obviously made the app crash.

There might be more reference that would need `_Nullable` annotation. I only added them there we I found them breaking my Swift app.
