### PR TITLE
Add optional completion handler to write methods and a hasPendingChanges property

### DIFF
--- a/DPHue.podspec
+++ b/DPHue.podspec
@@ -12,6 +12,7 @@ Pod::Spec.new do |s|
   s.source_files = 'DPHue/*.{h,m}'
   s.requires_arc = true
   s.dependency 'CocoaAsyncSocket', '~> 7.4.1'
-  s.ios.deployment_target = '7.0'
-  s.osx.deployment_target = '10.7'
+  s.ios.deployment_target  = '7.0'
+  s.osx.deployment_target  = '10.7'
+  s.tvos.deployment_target = '9.0'
 end

--- a/DPHue/DPHueBridge.h
+++ b/DPHue/DPHueBridge.h
@@ -155,15 +155,15 @@
           <br />
           The completion block takes two parameters:
           <ul>
-          <li>success<br />
-                Indicates whether the creation succeeded according to the controller
+          <li>error<br />
+                Holds the error, if any
           </li>
           <li>group<br />
-                The resultant group.
+                The resultant group, if created (i.e. no error occurred)
           </li>
           </ul>
  */
-- (void)createGroupWithName:(NSString *)name lightIds:(NSArray *)lightIds onCompletion:(void (^)(BOOL success, DPHueLightGroup* group))onCompletionBlock;
+- (void)createGroupWithName:(NSString *)name lightIds:(NSArray *)lightIds onCompletion:(void (^)(NSError* _Nullable success, DPHueLightGroup* _Nullable group))onCompletionBlock;
 
 /**
  Update the given group on the controller.

--- a/DPHue/DPHueBridge.m
+++ b/DPHue/DPHueBridge.m
@@ -252,7 +252,13 @@ const DPHueCommandQueueKey* DPHueCommandQueueKeyExpire = @"DPHueCommandQueueKeyE
       }
       
       [group parseGroupCreation:json];
-      onCompletionBlock( YES, group);
+      if (group.number) {
+        group.lightIds = lightIds;
+        onCompletionBlock(YES, group);
+      }
+      else {
+        onCompletionBlock(NO, nil);
+      }
     };
   }
   

--- a/DPHue/DPHueLight.h
+++ b/DPHue/DPHueLight.h
@@ -68,6 +68,8 @@
  */
 @property (nonatomic, assign) BOOL holdUpdates;
 
+/// YES if it has pending changes that haven't been yet written, otherwise NO
+@property (nonatomic, readonly) BOOL hasPendingChanges;
 
 #pragma mark - Properties you may be interested in reading
 
@@ -120,7 +122,13 @@
 - (void)read;
 
 /// Write only pending changes to controller
+- (void)writeWithCompletionHandler:(void(^ _Nullable )(NSError* _Nullable error))onCompleted;
+
+/// Write only pending changes to controller
 - (void)write;
+
+/// Write entire state to controller, regardless of changes
+- (void)writeAllWithCompletionHandler:(void(^ _Nullable )(NSError* _Nullable error))onCompleted;
 
 /// Write entire state to controller, regardless of changes
 - (void)writeAll;

--- a/DPHue/DPHueLight.h
+++ b/DPHue/DPHueLight.h
@@ -116,7 +116,7 @@
 - (void)alertLight;
 
 /// Re-download & parse controller's state for this particular light
-- (void)readWithSuccess:(void(^)(BOOL success))onCompleted;
+- (void)readWithCompletionHandler:(void(^ _Nullable )(NSError* _Nullable error))completion;
 
 /// Re-download & parse controller's state for this particular light
 - (void)read;

--- a/DPHue/DPHueLight.h
+++ b/DPHue/DPHueLight.h
@@ -22,13 +22,13 @@
 // immediate).
 
 /// Lamp brightness, valid values are 0 - 255.
-@property (nonatomic, strong) NSNumber *brightness;
+@property (nonatomic, strong) NSNumber* _Nullable brightness;
 
 /// Lamp hue, in degrees*182, valid valuse are 0 - 65535.
-@property (nonatomic, strong) NSNumber *hue;
+@property (nonatomic, strong) NSNumber* _Nullable hue;
 
 /// Lamp saturation, valid values are 0 - 255.
-@property (nonatomic, strong) NSNumber *saturation;
+@property (nonatomic, strong) NSNumber* _Nullable saturation;
 
 /**
  Lamp on (or off). When a lamp is told to turn on,
@@ -42,24 +42,24 @@
  Color in (x,y) CIE 1931 coordinates. See below URL for details:<br />
  <a href="http://en.wikipedia.org/wiki/CIE_1931" >http://en.wikipedia.org/wiki/CIE_1931</a>
  */
-@property (nonatomic, copy) NSArray *xy;
+@property (nonatomic, copy) NSArray* _Nullable xy;
 
 /// Color temperature in mireds, valid values are 154 - 500.
-@property (nonatomic, strong) NSNumber *colorTemperature;
+@property (nonatomic, strong) NSNumber* _Nullable colorTemperature;
 
 /**
  Specifies how quickly a lamp should change from its old state
  to new state. Supposedly a setting of 0 allows for instant
  changes, but this hasn't worked well for me.
  */
-@property (nonatomic, strong) NSNumber *transitionTime;
+@property (nonatomic, strong) NSNumber* _Nullable transitionTime;
 
 /**
  Current alert state.
  
  Possible values: ["none", "select", "lselect"]
  */
-@property (nonatomic, copy) NSString *alert;
+@property (nonatomic, copy) NSString* _Nullable alert;
 
 /**
  If set to YES, changes are held until [DPHueLight write] is called.
@@ -74,7 +74,7 @@
 #pragma mark - Properties you may be interested in reading
 
 /// Lamp name, as returned by the controller.
-@property (nonatomic, readonly, copy) NSString *name;
+@property (nonatomic, readonly, copy) NSString* _Nullable name;
 
 /**
  The API does not allow changing this value directly. Rather, the color
@@ -82,7 +82,7 @@
  For example, if you last set a lamp's colorTemperature value, then
  colormode would be "ct". If you set hue or saturation, it would be "hs".
  */
-@property (nonatomic, readonly, copy) NSString *colorMode; // "xy", "ct" or "hs"
+@property (nonatomic, readonly, copy) NSString* _Nullable colorMode; // "xy", "ct" or "hs"
 
 /**
  This returns the controller's best guess as to whether the lamp is
@@ -91,23 +91,23 @@
 @property (nonatomic, readonly, assign) BOOL reachable;
 
 /// Firmware version of the lamp.
-@property (nonatomic, readonly, copy) NSString *swversion;
+@property (nonatomic, readonly, copy) NSString* _Nullable swversion;
 
 /// Lamp model type.
-@property (nonatomic, readonly, copy) NSString *type;
+@property (nonatomic, readonly, copy) NSString* _Nullable type;
 
 /// The number of the lamp, assigned by the controller.
-@property (nonatomic, strong) NSNumber *number;
+@property (nonatomic, strong) NSNumber* _Nullable number;
 
 /// Lamp model ID.
-@property (nonatomic, readonly, copy) NSString *modelid;
+@property (nonatomic, readonly, copy) NSString* _Nullable modelid;
 
 
 #pragma mark - Properties you can probably ignore
 
-@property (nonatomic, copy) NSString *username;
-@property (nonatomic, copy) NSString *host;
-@property (nonatomic, readonly) NSString* address;
+@property (nonatomic, copy) NSString* _Nullable username;
+@property (nonatomic, copy) NSString* _Nullable host;
+@property (nonatomic, readonly) NSString* _Nullable address;
 
 @property (nonatomic, weak) DPHueBridge *bridge;
 

--- a/DPHue/DPHueLight.h
+++ b/DPHue/DPHueLight.h
@@ -97,7 +97,7 @@
 @property (nonatomic, readonly, copy) NSString* _Nullable type;
 
 /// The number of the lamp, assigned by the controller.
-@property (nonatomic, strong) NSNumber* _Nullable number;
+@property (nonatomic, strong) NSNumber* _Nonnull number;
 
 /// Lamp model ID.
 @property (nonatomic, readonly, copy) NSString* _Nullable modelid;
@@ -105,9 +105,9 @@
 
 #pragma mark - Properties you can probably ignore
 
-@property (nonatomic, copy) NSString* _Nullable username;
-@property (nonatomic, copy) NSString* _Nullable host;
-@property (nonatomic, readonly) NSString* _Nullable address;
+@property (nonatomic, copy) NSString* _Nonnull username;
+@property (nonatomic, copy) NSString* _Nonnull host;
+@property (nonatomic, readonly) NSString* _Nonnull address;
 
 @property (nonatomic, weak) DPHueBridge *bridge;
 

--- a/DPHue/DPHueLight.m
+++ b/DPHue/DPHueLight.m
@@ -180,19 +180,19 @@
     [self.pendingChanges addEntriesFromDictionary:pendingChanges];
 }
 
-- (void)readWithSuccess:(void(^)(BOOL success))onCompleted {
+- (void)readWithCompletionHandler:(void (^)(NSError * _Nullable))completion {
     NSURLRequest *request = [self requestForGettingLightState];
     DPJSONConnection *connection = [[DPJSONConnection alloc] initWithRequest:request sender:self];
     connection.completionBlock = ^(DPHueLight *sender, id json, NSError *err) {
         if (err) {
-            if (onCompleted)
-                onCompleted(NO);
+            if (completion)
+                completion(err);
             return;
         }
         
         [sender parseLightStateGet:json];
-        if (onCompleted)
-            onCompleted(YES);
+        if (completion)
+            completion(nil);
     };
     
     if (_bridge) {
@@ -203,7 +203,7 @@
 }
 
 - (void)read {
-    [self readWithSuccess:nil];
+    [self readWithCompletionHandler:nil];
 }
 
 - (void)writeAllWithCompletionHandler:(void (^ _Nullable )(NSError * _Nullable))onCompleted {

--- a/DPHue/DPHueLight.m
+++ b/DPHue/DPHueLight.m
@@ -10,6 +10,7 @@
 #import "DPHueLight.h"
 #import "DPHueBridge.h"
 #import "DPJSONConnection.h"
+#import "NSNumber+Clamp.h"
 #import "WSLog.h"
 
 
@@ -111,15 +112,6 @@
 
 #pragma mark - Setters that update pendingChanges
 
-NSNumber* _clampNumber(NSNumber* number, NSInteger low, NSInteger high) {
-    NSInteger val = number.integerValue;
-    if (val > high)
-        return @(high);
-    if (val < low)
-        return @(low);
-    return number;
-}
-
 - (void)setOn:(BOOL)on {
     _on = on;
     self.pendingChanges[@"on"] = [NSNumber numberWithBool:on];
@@ -128,14 +120,14 @@ NSNumber* _clampNumber(NSNumber* number, NSInteger low, NSInteger high) {
 }
 
 - (void)setBrightness:(NSNumber *)brightness {
-    _brightness = _clampNumber(brightness, 0, 255);
+    _brightness = [brightness clampFrom: @0 to: @255];
     self.pendingChanges[@"bri"] = _brightness;
     if (!self.holdUpdates)
         [self write];
 }
 
 - (void)setHue:(NSNumber *)hue {
-    _hue = _clampNumber(hue, 0, 65535);
+    _hue = [hue clampFrom: @0 to: @65535];
     self.pendingChanges[@"hue"] = _hue;
     if (!self.holdUpdates)
         [self write];
@@ -150,7 +142,7 @@ NSNumber* _clampNumber(NSNumber* number, NSInteger low, NSInteger high) {
 }
 
 - (void)setColorTemperature:(NSNumber *)colorTemperature {
-    _colorTemperature = _clampNumber(colorTemperature, 154, 500);
+    _colorTemperature = [colorTemperature clampFrom: @154 to: @500];
     self.pendingChanges[@"ct"] = _colorTemperature;
     if (!self.holdUpdates)
         [self write];
@@ -165,7 +157,7 @@ NSNumber* _clampNumber(NSNumber* number, NSInteger low, NSInteger high) {
 }
 
 - (void)setSaturation:(NSNumber *)saturation {
-    _saturation = _clampNumber(saturation, 0, 255);
+    _saturation = [saturation clampFrom: @0 to: @255];
     self.pendingChanges[@"sat"] = _saturation;
     if (!self.holdUpdates)
         [self write];

--- a/DPHue/DPHueLight.m
+++ b/DPHue/DPHueLight.m
@@ -128,15 +128,15 @@ NSNumber* _clampNumber(NSNumber* number, NSInteger low, NSInteger high) {
 }
 
 - (void)setBrightness:(NSNumber *)brightness {
-    _brightness = (brightness = _clampNumber(brightness, 0, 255));
-    self.pendingChanges[@"bri"] = brightness;
+    _brightness = _clampNumber(brightness, 0, 255);
+    self.pendingChanges[@"bri"] = _brightness;
     if (!self.holdUpdates)
         [self write];
 }
 
 - (void)setHue:(NSNumber *)hue {
-    _hue = (hue = _clampNumber(hue, 0, 65535));
-    self.pendingChanges[@"hue"] = hue;
+    _hue = _clampNumber(hue, 0, 65535);
+    self.pendingChanges[@"hue"] = _hue;
     if (!self.holdUpdates)
         [self write];
 }
@@ -150,8 +150,8 @@ NSNumber* _clampNumber(NSNumber* number, NSInteger low, NSInteger high) {
 }
 
 - (void)setColorTemperature:(NSNumber *)colorTemperature {
-    _colorTemperature = (colorTemperature = _clampNumber(colorTemperature, 154, 500));
-    self.pendingChanges[@"ct"] = colorTemperature;
+    _colorTemperature = _clampNumber(colorTemperature, 154, 500);
+    self.pendingChanges[@"ct"] = _colorTemperature;
     if (!self.holdUpdates)
         [self write];
 }
@@ -165,8 +165,8 @@ NSNumber* _clampNumber(NSNumber* number, NSInteger low, NSInteger high) {
 }
 
 - (void)setSaturation:(NSNumber *)saturation {
-    _saturation = saturation;
-    self.pendingChanges[@"sat"] = (saturation = _clampNumber(saturation, 0, 255));
+    _saturation = _clampNumber(saturation, 0, 255);
+    self.pendingChanges[@"sat"] = _saturation;
     if (!self.holdUpdates)
         [self write];
 }

--- a/DPHue/DPHueLight.m
+++ b/DPHue/DPHueLight.m
@@ -216,12 +216,12 @@
     [self readWithCompletionHandler:nil];
 }
 
-- (void)writeAllWithCompletionHandler:(void (^ _Nullable )(NSError * _Nullable))onCompleted {
+- (void)writeAllWithCompletionHandler:(void (^ _Nullable )(NSError * _Nullable))completion {
     if (!self.on) {
         // If bulb is off, it forbids changes, so send none
         // except to turn it off
         self.pendingChanges[@"on"] = [NSNumber numberWithBool:self.on];
-        [self write];
+        [self writeWithCompletionHandler:completion];
         return;
     }
     self.pendingChanges[@"on"] = [NSNumber numberWithBool:self.on];
@@ -239,7 +239,7 @@
     if ([self.colorMode isEqualToString:@"ct"]) {
         self.pendingChanges[@"ct"] = self.colorTemperature;
     }
-    [self writeWithCompletionHandler:onCompleted];
+    [self writeWithCompletionHandler:completion];
 }
 
 - (void)writeAll {

--- a/DPHue/DPHueLight.m
+++ b/DPHue/DPHueLight.m
@@ -367,7 +367,6 @@
   if (errorFound)
   {
     _writeSuccess = NO;
-    NSLog(@"Error writing values!\n%@", _writeMessage);
   }
   else
   {

--- a/DPHue/DPHueLight.m
+++ b/DPHue/DPHueLight.m
@@ -35,8 +35,11 @@
 
 - (void)performCommonInit
 {
-  self.holdUpdates = YES;
-  self.pendingChanges = [NSMutableDictionary new];
+  _number = @-1;
+  _username = @"";
+  _host = @"";
+  _holdUpdates = YES;
+  _pendingChanges = [NSMutableDictionary new];
 }
 
 - (NSString *)description {

--- a/DPHue/DPHueLight.m
+++ b/DPHue/DPHueLight.m
@@ -252,14 +252,23 @@
 
   DPJSONConnection *connection = [[DPJSONConnection alloc] initWithRequest:request sender:self];
   connection.completionBlock = ^(DPHueLight *sender, id json, NSError *err) {
-    if (onCompleted) {
-      onCompleted(err);
-    }
-
-    if ( err )
+    if ( err ) {
+      if (onCompleted) {
+        onCompleted(err);
+      }
       return;
+    }
     
     [sender parseLightStateSet:json];
+
+    if (onCompleted) {
+      if (self.writeSuccess) {
+        onCompleted(nil);
+      }
+      else {
+        onCompleted([NSError errorWithDomain:@"DPHue" code:1 userInfo:@{NSLocalizedDescriptionKey: self.writeMessage}]);
+      }
+    }
   };
    
     if (_bridge) {

--- a/DPHue/DPHueLight.m
+++ b/DPHue/DPHueLight.m
@@ -189,6 +189,16 @@
                 completion(err);
             return;
         }
+
+        if ([json isKindOfClass:[NSArray class]]) {
+          NSString *errorDescription = ((NSArray*)json).firstObject[@"error"][@"description"];
+          if (errorDescription) {
+            if (completion) {
+              completion([NSError errorWithDomain:@"DPHue" code:5 userInfo:@{NSLocalizedDescriptionKey: errorDescription}]);
+            }
+            return;
+          }
+        }
         
         [sender parseLightStateGet:json];
         if (completion)

--- a/DPHue/DPHueLightGroup.h
+++ b/DPHue/DPHueLightGroup.h
@@ -68,6 +68,8 @@
  */
 @property (nonatomic, assign) BOOL holdUpdates;
 
+/// YES if it has pending changes that haven't been yet written, otherwise NO
+@property (nonatomic, readonly) BOOL hasPendingChanges;
 
 #pragma mark - Properties you may be interested in reading
 
@@ -102,7 +104,13 @@
 - (void)read;
 
 /// Write only pending changes to controller
+- (void)writeWithCompletionHandler:(void(^ _Nullable )(NSError* _Nullable error))onCompleted;
+
+/// Write only pending changes to controller
 - (void)write;
+
+/// Write entire state to controller, regardless of changes
+- (void)writeAllWithCompletionHandler:(void(^ _Nullable )(NSError* _Nullable error))onCompleted;
 
 /// Write entire state to controller, regardless of changes
 - (void)writeAll;

--- a/DPHue/DPHueLightGroup.h
+++ b/DPHue/DPHueLightGroup.h
@@ -101,6 +101,9 @@
 #pragma mark - Methods
 
 /// Re-download & parse controller's state for this particular group
+- (void)readWithCompletionHandler:(void(^ _Nullable )(NSError* _Nullable error))completion;
+
+/// Re-download & parse controller's state for this particular group
 - (void)read;
 
 /// Write only pending changes to controller

--- a/DPHue/DPHueLightGroup.m
+++ b/DPHue/DPHueLightGroup.m
@@ -359,7 +359,7 @@
   {
     NSString *idStr = result[@"success"][@"id"];
     NSError *error = nil;
-    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"^/groups/(\\d+)$"
+    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"^(?:/groups/)?(\\d+)$"
                                                                            options:NSRegularExpressionCaseInsensitive
                                                                              error:&error];
     NSTextCheckingResult *match;

--- a/DPHue/DPHueLightGroup.m
+++ b/DPHue/DPHueLightGroup.m
@@ -429,7 +429,6 @@
   if (errorFound)
   {
     _writeSuccess = NO;
-    NSLog(@"Error writing values!\n%@", _writeMessage);
   }
   else
   {

--- a/DPHue/DPHueLightGroup.m
+++ b/DPHue/DPHueLightGroup.m
@@ -195,7 +195,7 @@
     // If bulb is off, it forbids changes, so send none
     // except to turn it off
     self.pendingChanges[@"on"] = [NSNumber numberWithBool:self.on];
-    [self write];
+    [self writeWithCompletionHandler:completion];
     return;
   }
   

--- a/DPHue/DPHueLightGroup.m
+++ b/DPHue/DPHueLightGroup.m
@@ -159,6 +159,16 @@
       }
       return;
     }
+
+    if ([json isKindOfClass:[NSArray class]]) {
+      NSString *errorDescription = ((NSArray*)json).firstObject[@"error"][@"description"];
+      if (errorDescription) {
+        if (completion) {
+          completion([NSError errorWithDomain:@"DPHue" code:5 userInfo:@{NSLocalizedDescriptionKey: errorDescription}]);
+        }
+        return;
+      }
+    }
     
     [sender parseGroupStateGet:json];
     if (completion) {

--- a/DPHue/DPHueLightGroup.m
+++ b/DPHue/DPHueLightGroup.m
@@ -148,15 +148,22 @@
 
 #pragma mark - Public API
 
-- (void)read
+- (void)readWithCompletionHandler:(void(^ _Nullable )(NSError* _Nullable error))completion
 {
   NSURLRequest *request = [self requestForGettingGroupState];
   DPJSONConnection *connection = [[DPJSONConnection alloc] initWithRequest:request sender:self];
   connection.completionBlock = ^(DPHueLightGroup *sender, id json, NSError *err) {
-    if ( err )
+    if ( err ) {
+      if (completion) {
+        completion(err);
+      }
       return;
+    }
     
     [sender parseGroupStateGet:json];
+    if (completion) {
+      completion(nil);
+    }
   };
   
     if (_bridge) {
@@ -164,6 +171,11 @@
     } else {
         [connection start];
     }
+}
+
+- (void)read
+{
+    [self readWithCompletionHandler:nil];
 }
 
 - (void)writeAllWithCompletionHandler:(void (^ _Nullable )(NSError * _Nullable))completion

--- a/DPHue/DPHueLightGroup.m
+++ b/DPHue/DPHueLightGroup.m
@@ -220,13 +220,23 @@
   
   DPJSONConnection *connection = [[DPJSONConnection alloc] initWithRequest:request sender:self];
   connection.completionBlock = ^(DPHueLightGroup *sender, id json, NSError *err) {
-    if (completion) {
-      completion(err);
-    }
-    if ( err )
+    if ( err ) {
+      if (completion) {
+        completion(err);
+      }
       return;
-    
+    }
+
     [sender parseGroupStateSet:json];
+
+    if (completion) {
+      if (self.writeSuccess) {
+        completion(nil);
+      }
+      else {
+        completion([NSError errorWithDomain:@"DPHue" code:2 userInfo:@{NSLocalizedDescriptionKey: self.writeMessage}]);
+      }
+    }
   };
   
     if (_bridge) {

--- a/DPHue/DPHueLightGroup.m
+++ b/DPHue/DPHueLightGroup.m
@@ -10,6 +10,7 @@
 #import "DPHueLightGroup.h"
 #import "DPJSONConnection.h"
 #import "DPHueBridge.h"
+#import "NSNumber+Clamp.h"
 
 @interface DPHueLightGroup ()
 
@@ -95,16 +96,16 @@
 
 - (void)setBrightness:(NSNumber *)brightness
 {
-  _brightness = brightness;
-  self.pendingChanges[@"bri"] = brightness;
+  _brightness = [brightness clampFrom: @0 to: @255];
+  self.pendingChanges[@"bri"] = _brightness;
   if (!self.holdUpdates)
     [self write];
 }
 
 - (void)setHue:(NSNumber *)hue
 {
-  _hue = hue;
-  self.pendingChanges[@"hue"] = hue;
+  _hue = [hue clampFrom: @0 to: @65535];
+  self.pendingChanges[@"hue"] = _hue;
   if (!self.holdUpdates)
     [self write];
 }
@@ -119,8 +120,8 @@
 
 - (void)setColorTemperature:(NSNumber *)colorTemperature
 {
-  _colorTemperature = colorTemperature;
-  self.pendingChanges[@"ct"] = colorTemperature;
+  _colorTemperature = [colorTemperature clampFrom: @154 to: @500];
+  self.pendingChanges[@"ct"] = _colorTemperature;
   if (!self.holdUpdates)
     [self write];
 }
@@ -135,8 +136,8 @@
 
 - (void)setSaturation:(NSNumber *)saturation
 {
-  _saturation = saturation;
-  self.pendingChanges[@"sat"] = saturation;
+  _saturation = [saturation clampFrom: @0 to:@255];
+  self.pendingChanges[@"sat"] = _saturation;
   if (!self.holdUpdates)
     [self write];
 }

--- a/DPHue/DPHueLightGroup.m
+++ b/DPHue/DPHueLightGroup.m
@@ -141,6 +141,10 @@
     [self write];
 }
 
+- (BOOL)hasPendingChanges {
+    return self.pendingChanges.count > 0;
+}
+
 #pragma mark - Public API
 
 - (void)read
@@ -161,7 +165,7 @@
     }
 }
 
-- (void)writeAll
+- (void)writeAllWithCompletionHandler:(void (^ _Nullable )(NSError * _Nullable))completion
 {
   if (!self.on)
   {
@@ -191,10 +195,14 @@
     self.pendingChanges[@"ct"] = self.colorTemperature;
   }
   
-  [self write];
+  [self writeWithCompletionHandler:completion];
 }
 
-- (void)write
+- (void)writeAll {
+    [self writeAllWithCompletionHandler:nil];
+}
+
+- (void)writeWithCompletionHandler:(void(^ _Nullable )(NSError* _Nullable error))completion
 {
   if (!self.pendingChanges.count)
     return;
@@ -211,6 +219,9 @@
   
   DPJSONConnection *connection = [[DPJSONConnection alloc] initWithRequest:request sender:self];
   connection.completionBlock = ^(DPHueLightGroup *sender, id json, NSError *err) {
+    if (completion) {
+      completion(err);
+    }
     if ( err )
       return;
     
@@ -223,6 +234,11 @@
         [connection start];
     }
 }
+
+- (void)write {
+    [self writeWithCompletionHandler:nil];
+}
+
 
 - (NSString *)description
 {

--- a/DPHue/NSNumber+Clamp.h
+++ b/DPHue/NSNumber+Clamp.h
@@ -1,0 +1,13 @@
+//
+//  NSNumber+Clamp.h
+//  Pods
+//
+//  Created by Lars Blumberg on 10/25/16.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSNumber (Clamp)
+- (NSNumber *)clampFrom:(NSNumber *) min to:(NSNumber *) max;
+@end

--- a/DPHue/NSNumber+Clamp.m
+++ b/DPHue/NSNumber+Clamp.m
@@ -1,0 +1,17 @@
+//
+//  NSNumber+Clamp.m
+//  Pods
+//
+//  Created by Lars Blumberg on 10/25/16.
+//
+//
+
+#import "NSNumber+Clamp.h"
+
+@implementation NSNumber (Clamp)
+- (NSNumber *)clampFrom:(NSNumber *) min to:(NSNumber *) max {
+    if (self.doubleValue > max.doubleValue) return max;
+    if (self.doubleValue < min.doubleValue) return min;
+    return self;
+}
+@end


### PR DESCRIPTION
These completion handlers allow callers to do run code after write requests have been sent.

In my case I set `holdUpdates` to `true` and I only write pending changes after the previous pending changes have been written.
